### PR TITLE
Fix runtime priv

### DIFF
--- a/libs/core/variant.cpp
+++ b/libs/core/variant.cpp
@@ -111,6 +111,8 @@ int main(int argc, char **argv) {
   (void)argc;
   (void)argv;
   exec_binary((int32_t*)functionsAndBytecode);
+
+  exitThread(0);
   return 0;
 }
 


### PR DESCRIPTION
This adds a threadExit() call to the main function, which should allow e.g. forever() threads to run.

It is untested, so please make sure it works before merging it.