### PR TITLE
Fix sensing block

### DIFF
--- a/libs/core/sensing.ts
+++ b/libs/core/sensing.ts
@@ -9,7 +9,12 @@ namespace sensing {
     //% blockId=sensing_pressed block="is|%name=digital_pin|%value"
     export function pressed(name: number, value: PulseValue = PulseValue.High): boolean {
         pins.pinMode(name, PinMode.Input);
-        return pins.digitalRead(name) == value ? true : false;
+        const readValue = pins.digitalRead(name);
+        switch(value) {
+            case PulseValue.High: return readValue > 0;
+            case PulseValue.Low: return readValue == 0;
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Fixes issue described by @nataliefreed in https://github.com/Microsoft/pxt-chibitronics/issues/95. 

I was previously under the assumption that the High sensing value is 1 and Low was 0. But it appears it's either a different specific value greater than 1, or it's a range. Either way, this fixes it.