### PR TITLE
libs: core: input: invert pin-mapping logic

### DIFF
--- a/libs/core/input.cpp
+++ b/libs/core/input.cpp
@@ -116,15 +116,15 @@ static void registerEvent(int dpin, uint8_t type, Action body)
     int pin = dpin;
     if ((pin >= (int)DigitalPin::D0) && (pin <= (int)DigitalPin::D5))
     {
-        pin &= ~0x7;
+        pin &= 0x7;
     }
     else if ((pin >= (int)AnalogPin::A0) && (pin <= (int)AnalogPin::A5))
     {
-        pin &= ~0x7;
+        pin &= 0x7;
     }
     else if ((pin >= 0) && (pin <= 5))
     {
-        pin &= ~0x7;
+        pin &= 0x7;
     }
     else
     {


### PR DESCRIPTION
Digital pins have several names.  There's the silk-screened name (i.e.
0, 1, 2, ...), the Arduino Digital name (i.e. D0, D1, D2, ...), and the
Arduino Analog name (i.e. A0, A1, A2, ...).

Inside input.cpp, we canonicalize the input pin to ensure it is
accurate.  However, the logic was inverted, and instead of masking off
everything but the pin number, we were masking off the pin number and
leaving everything else.

This caused the pin number to always be set to pin 0.

Invert this logic to leave only the lower three bits.

This closes issue #163.

Signed-off-by: Sean Cross <sean@xobs.io>