### PR TITLE
Fix loading of 'press for color' example

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -39,9 +39,8 @@ Here are some advanced examples, for intrepid code explorers!
 {
   "name": "Press for Color",
   "url":"/examples/rgb/press-for-color",
-  "cardType": "codeExample",
+  "cardType": "example",
   "imageUrl":"/static/chibi/examples/pressforcolor.gif",
   "description": "Change the colors of the RGB LED by connecting a pin to ground."
-
 }]
 ```

--- a/docs/examples/rgb/press-for-color.md
+++ b/docs/examples/rgb/press-for-color.md
@@ -2,7 +2,7 @@
 
 Change the colors of the RGB pixel by connecting a pin to ground.
 
-Pin 0 changes the color of pixel 0 (on the Chibi Chip board)
+Pin **0** changes the color of pixel **0** (on the Chibi Chip board).
 
 ```blocks
 let RATE = 3 // a number larger than 1, less than 20, rate at which the colors change during pin press
@@ -13,12 +13,14 @@ let HUE_DEGREE = 512 // hue is 0 ... (360*HUE_DEGREE - 1)
 let pinHue = 0;
 let pinDir = RATE;
 let hue = 0;
+let s = 0;
+let v = 0;
 let c = 0;
 
-pins.pinMode(DigitalPin.D0, PinMode.PullUp)
+pins.pinMode(DigitalPin.D0, PinMode.PullUp);
 
 loops.forever(() => {
-    if (pins.digitalRead(DigitalPin.D0) == PulseValue.Low) {
+    if (pins.digitalRead(DigitalPin.D0) == 0) {
         pinHue += pinDir;
         if (pinHue >= HUE_DEGREE) {
             pinDir = -pinDir;
@@ -30,39 +32,47 @@ loops.forever(() => {
     }
     hue = Math.map(pinHue, 0, 1023, 0, HUE_DEGREE);
     hue = (360 * hue) - 1;
+    s = Math.map(SATURATION, 0, 100, 0, 255);
+    v = Math.map(INTENSITY, 0, 100, 0, 255);
 
-    c = hsv2rgb(hue, Math.map(SATURATION, 0, 100, 0, 255), Math.map(INTENSITY, 0, 100, 0, 255));
+    hsv2rgb();
 
     rgb.setColor(c)
     loops.pause(10);
 })
 
 // from https://gist.github.com/mity/6034000
-function hsv2rgb(h: number, s: number, v: number): number {
-    let r = 0, g = 0, b = 0;
+function hsv2rgb( ) {
+    let r = 0; 
+    let g = 0;
+    let b = 0;
 
     if (s == 0) {
-        r = g = b = v;
+        r = v; g = v; b = v;
     } else {
-        let i = h / (60 * HUE_DEGREE);
+        let i = hue / (60 * HUE_DEGREE);
         let p = (256 * v - s * v) / 256;
 
-        if (i & 1) {
-            let q = (256 * 60 * HUE_DEGREE * v - h * s * v + 60 * HUE_DEGREE * s * v * i) / (256 * 60 * HUE_DEGREE);
-            switch (i) {
-                case 1: r = q; g = v; b = p; break;
-                case 3: r = p; g = q; b = v; break;
-                case 5: r = v; g = p; b = q; break;
+        if (i % 2 == 1) {
+            let q = (256 * 60 * HUE_DEGREE * v - hue * s * v + 60 * HUE_DEGREE * s * v * i) / (256 * 60 * HUE_DEGREE);
+            if (i == 1) {
+                r = q; g = v; b = p;
+            } else if (i == 3) {
+                r = p; g = q; b = v;
+            } else if (i == 5) {
+                r = v; g = p; b = q;
             }
         } else {
-            let t = (256 * 60 * HUE_DEGREE * v + h * s * v - 60 * HUE_DEGREE * s * v * (i + 1)) / (256 * 60 * HUE_DEGREE);
-            switch (i) {
-                case 0: r = v; g = t; b = p; break;
-                case 2: r = p; g = v; b = t; break;
-                case 4: r = t; g = p; b = v; break;
+            let t = (256 * 60 * HUE_DEGREE * v + hue * s * v - 60 * HUE_DEGREE * s * v * (i + 1)) / (256 * 60 * HUE_DEGREE);
+            if (i == 0) {
+                r = v; g = t; b = p;
+            } else if (i == 2) {
+                r = p; g = v; b = t;
+            } else if (i == 4) {
+                r = t; g = p; b = v;
             }
         }
     }
-    return rgb.rgb(r, g, b);
+    c = rgb.rgb(r, g, b)
 }
 ```


### PR DESCRIPTION
Fixes #156.

- [x] Fix code card entry for example.
- [x] Refactor example to decompile to blocks better (make hsv2rgb a simple function).