### PR TITLE
adding troubleshooting instructions

### DIFF
--- a/docs/upload.md
+++ b/docs/upload.md
@@ -1,0 +1,39 @@
+# Upload
+
+Follow these steps carefully to upload the code to your @boardname@.
+
+## Step 1
+
+Plug the cable into your @boardname@.
+
+![Plugin](./static/download/plugin.png)
+
+
+## Step 2
+
+Plug the USB and audio cables into your programming device. Make sure that the audio cable goes into the headphones plug, not the microphone.
+
+![Plug USB and audio](./static/download/plugincomp.png)
+
+## Step 3
+
+Press and hold the PROG button until the PROG light is steady red.
+
+![reset](./static/download/reset.png)
+
+When done, click the ``||Ready||`` button!
+
+## Troubleshooting
+
+### Try again!
+
+The sound gets sometimes distorded by the computer, try again and you might be more lucky.
+
+### Check your sound volume
+
+Make sure your computer volume is all the way to 100% so that the board receives a clear sound.
+
+### Check your Audio cable
+
+Make sure the audio cable is in the headphone port, not the microphone.
+

--- a/editor/extension.ts
+++ b/editor/extension.ts
@@ -11,6 +11,7 @@ namespace chibitronics {
             return Promise.resolve();
         }
         const boardName = pxt.appTarget.appTheme.boardName;
+        const docUrl = pxt.appTarget.appTheme.usbDocs;
         const htmlBody = `
         <div class="ui three column grid stackable">
             <div class="column">
@@ -57,8 +58,14 @@ namespace chibitronics {
             header: lf("Upload instructions"),
             htmlBody,
             hideCancel: true,
-            agreeLbl: lf("Ready?")
-        }).then(() => { });
+            agreeLbl: lf("Ready?"),
+            buttons: [docUrl ? {
+                label: lf("Help"),
+                icon: "help",
+                class: "lightgrey focused",
+                url: docUrl
+            } : undefined]
+}).then(() => { });
     }
     function showIEUploadInstructionsAsync(confirmAsync: (confirmOptions: {}) => Promise<number>, fn: string, url: string): Promise<void> {
         if (!confirmAsync) {

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -155,6 +155,7 @@
         "boardName": "Chibi Chip",
         "showHomeScreen": true,
         "homeScreenHero": "./static/getting-started/getting-started.png",
+        "usbDocs": "/upload",
         "sideDoc": "tutorials/getting-started",
         "docMenu": [
             {


### PR DESCRIPTION
Adding "Help" button in upload dialog. The documentation page should be beefed as we learn in how many ways the upload can fail.