### PR TITLE
Literals vs macros in codecards

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -10,7 +10,7 @@ Here are some fun programs for your @boardname@!
   "url":"/examples/basics/fade",
   "cardType": "example",
   "imageUrl":"/static/chibi/examples/mc-fade-final.gif",
-  "description": "See how @boardname@ can change the brightness of an LED."
+  "description": "See how Chibi Chip can change the brightness of an LED."
 }]
 ```
 

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -12,7 +12,7 @@ Here are some tutorials to get you started with your @boardname@!
     "imageUrl":"/static/chibi/tutorials/getting-started.png",
     "label": "New? Start Here!",
     "labelClass": "red ribbon large tutorial",
-    "description": "Start coding your @boardname@ with this simple tutorial."
+    "description": "Start coding your Chibi Chip with this simple tutorial."
 }]
 ```
 
@@ -23,6 +23,6 @@ Here are some tutorials to get you started with your @boardname@!
     "name":"Complete the Circuit!", 
     "url":"/make/complete-the-circuit", 
     "imageUrl":"/static/cp/tutorial/ctc.jpg",
-    "description": "Using copper tape, create a circuit to turn on and off some LED lights on your @boardname@!"
+    "description": "Using copper tape, create a circuit to turn on and off some LED lights on your Chibi Chip!"
 }]
 ```


### PR DESCRIPTION
Fix for #178. Use actual board name and not the macro in the codecards.