### PR TITLE
Fixing default value for RGB

### DIFF
--- a/libs/core/rgb.ts
+++ b/libs/core/rgb.ts
@@ -33,7 +33,7 @@ namespace rgb {
 
     /**
      * Make the on-board RGB LED show an RGB color (range 0-255 for r, g, b).
-     * @param rgb RGB color of the LED, eg: Colors.Red
+     * @param rgb RGB color of the LED, eg: 0xff0000
      */
     //% blockId="rgb_set_color" block="set rgb to %rgb=colorNumberPicker"
     //% weight=90 help="rgb/set-color"


### PR DESCRIPTION
A recent change I made to pxt-core fixed the default values for shadow blocks (they were previously being ignored). This just fixes the default value from an enum value to the hex syntax because the enum was causing the color picker to throw an exception in the toolbox.