### PR TITLE
Fix twinkle effect

### DIFF
--- a/libs/core/input.cpp
+++ b/libs/core/input.cpp
@@ -3,7 +3,7 @@
 #include "pins.h"
 #include "ChibiOS.h"
 
-#define POLL_PIN_STACK_SIZE 256
+#define POLL_PIN_STACK_SIZE 400
 
 #define EVENT_TYPE_NONE 0
 #define EVENT_TYPE_FALLING 1

--- a/libs/core/input.cpp
+++ b/libs/core/input.cpp
@@ -92,9 +92,6 @@ static void pinPollThread(void *ptr)
 
 static void spawnPinPollThread(void)
 {
-    static int sp = 0;
-    printf("Sp:%d\n", ++sp);
-
     // Don't re-spawn the thread.
     if (events)
         return;


### PR DESCRIPTION
The poll stack size was 256 bytes, which was not enough for certain
effects such as "Twinkle".  Increase the stack size to 400 bytes, which
matches the stack size for normal `forever()` threads.

This fixes issue #234.
